### PR TITLE
Factor out magic numbers relating to String to Key

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -23,6 +23,15 @@ import (
 	"github.com/fluidkeys/crypto/openpgp/s2k"
 )
 
+// https://tools.ietf.org/html/rfc4880#section-5.5.3
+const (
+	S2KUsageConventionUnencrypted = 0
+
+	S2KUsageConventionPlaintextChecksum = 255
+
+	S2KUsageConventionEncryptedSha1 = 254
+)
+
 // PrivateKey represents a possibly encrypted private key. See RFC 4880,
 // section 5.5.3.
 type PrivateKey struct {
@@ -95,10 +104,10 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 	s2kType := buf[0]
 
 	switch s2kType {
-	case 0:
+	case S2KUsageConventionUnencrypted:
 		pk.s2k = nil
 		pk.Encrypted = false
-	case 254, 255:
+	case S2KUsageConventionEncryptedSha1, S2KUsageConventionPlaintextChecksum:
 		_, err = readFull(r, buf[:])
 		if err != nil {
 			return
@@ -109,7 +118,7 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 		if err != nil {
 			return
 		}
-		if s2kType == 254 {
+		if s2kType == S2KUsageConventionEncryptedSha1 {
 			pk.sha1Checksum = true
 		}
 	default:

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -65,11 +65,14 @@ func (c *Config) hash() crypto.Hash {
 }
 
 func (c *Config) encodedCount() uint8 {
+	var i int
+
 	if c == nil || c.S2KCount == 0 {
-		return 96 // The common case. Correspoding to 65536
+		i = S2KCountDefault
+	} else {
+		i = c.S2KCount
 	}
 
-	i := c.S2KCount
 	switch {
 	// Behave like GPG. Should we make 65536 the lowest value used?
 	case i < S2KCountMin:

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -18,6 +18,12 @@ import (
 type stringToKeySpecifier = uint8
 
 const (
+	S2KCountMin     = 1024
+	S2KCountDefault = 65536
+	S2KCountMax     = 65011712
+)
+
+const (
 	// https://tools.ietf.org/html/rfc4880#section-3.7.1.1
 	SimpleS2K stringToKeySpecifier = 0
 
@@ -66,10 +72,10 @@ func (c *Config) encodedCount() uint8 {
 	i := c.S2KCount
 	switch {
 	// Behave like GPG. Should we make 65536 the lowest value used?
-	case i < 1024:
-		i = 1024
-	case i > 65011712:
-		i = 65011712
+	case i < S2KCountMin:
+		i = S2KCountMin
+	case i > S2KCountMax:
+		i = S2KCountMax
 	}
 
 	return encodeCount(i)
@@ -81,7 +87,7 @@ func (c *Config) encodedCount() uint8 {
 // if i is not in the above range (encodedCount above takes care to
 // pass i in the correct range). See RFC 4880 Section 3.7.7.1.
 func encodeCount(i int) uint8 {
-	if i < 1024 || i > 65011712 {
+	if i < S2KCountMin || i > S2KCountMax {
 		panic("count arg i outside the required range")
 	}
 

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -15,6 +15,19 @@ import (
 	"github.com/fluidkeys/crypto/openpgp/errors"
 )
 
+type stringToKeySpecifier = uint8
+
+const (
+	// https://tools.ietf.org/html/rfc4880#section-3.7.1.1
+	SimpleS2K stringToKeySpecifier = 0
+
+	// https://tools.ietf.org/html/rfc4880#section-3.7.1.2
+	SaltedS2K stringToKeySpecifier = 1
+
+	// https://tools.ietf.org/html/rfc4880#section-3.7.1.3
+	IteratedAndSaltedS2K stringToKeySpecifier = 3
+)
+
 // Config collects configuration parameters for s2k key-stretching
 // transformatioms. A nil *Config is valid and results in all default
 // values. Currently, Config is used only by the Serialize function in
@@ -171,12 +184,12 @@ func Parse(r io.Reader) (f func(out, in []byte), err error) {
 	h := hash.New()
 
 	switch buf[0] {
-	case 0:
+	case SimpleS2K:
 		f := func(out, in []byte) {
 			Simple(out, h, in)
 		}
 		return f, nil
-	case 1:
+	case SaltedS2K:
 		_, err = io.ReadFull(r, buf[:8])
 		if err != nil {
 			return
@@ -185,7 +198,7 @@ func Parse(r io.Reader) (f func(out, in []byte), err error) {
 			Salted(out, h, in, buf[:8])
 		}
 		return f, nil
-	case 3:
+	case IteratedAndSaltedS2K:
 		_, err = io.ReadFull(r, buf[:9])
 		if err != nil {
 			return
@@ -206,7 +219,7 @@ func Parse(r io.Reader) (f func(out, in []byte), err error) {
 // nil. In that case, sensible defaults will be used.
 func Serialize(w io.Writer, key []byte, rand io.Reader, passphrase []byte, c *Config) error {
 	var buf [11]byte
-	buf[0] = 3 /* iterated and salted */
+	buf[0] = IteratedAndSaltedS2K
 	buf[1], _ = HashToHashId(c.hash())
 	salt := buf[2:10]
 	if _, err := io.ReadFull(rand, salt); err != nil {


### PR DESCRIPTION
* Define S2KCountMin S2KCountMax S2KCountCommon

  -  S2KCountMin     = 1024
  -  S2KCountDefault = 65536      // by convention
  -  S2KCountMax     = 65011712

* Define S2K magic numbers 0, 254, 255
  -  S2K Unencrypted = 0
  -  S2K PlaintextChecksum = 255
  -  S2K EncryptedSha1 = 254

* Define SimpleS2K SaltedS2K IteratedAndSaltedS2K

  -  SimpleS2K = 0
  -  SaltedS2K = 1
  -  IteratedAndSaltedS2K = 3