### PR TITLE
Add PrivateKey.SerializeEncrypted (some TODOs)

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -549,7 +549,7 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 // Identities and subkeys are re-signed in case they changed since NewEntry.
 // If config is nil, sensible defaults will be used.
 func (e *Entity) SerializePrivate(w io.Writer, config *packet.Config) (err error) {
-	err = e.PrivateKey.Serialize(w)
+	err = e.PrivateKey.Serialize(w, config)
 	if err != nil {
 		return
 	}
@@ -568,7 +568,7 @@ func (e *Entity) SerializePrivate(w io.Writer, config *packet.Config) (err error
 		}
 	}
 	for _, subkey := range e.Subkeys {
-		err = subkey.PrivateKey.Serialize(w)
+		err = subkey.PrivateKey.Serialize(w, config)
 		if err != nil {
 			return
 		}

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	// RSABits is the number of bits in new RSA keys made with NewEntity.
 	// If zero, then 2048 bit keys are created.
 	RSABits int
+
+	SerializePrivatePassword string
 }
 
 func (c *Config) Random() io.Reader {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -12,6 +12,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/sha1"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -122,7 +123,7 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 			pk.sha1Checksum = true
 		}
 	default:
-		return errors.UnsupportedError("deprecated s2k function in private key")
+		return errors.UnsupportedError(fmt.Sprintf("deprecated s2k function in private key, s2kType: %v", s2kType))
 	}
 
 	if pk.Encrypted {
@@ -308,7 +309,7 @@ func (pk *PrivateKey) Decrypt(passphrase []byte) error {
 		h.Write(data[:len(data)-sha1.Size])
 		sum := h.Sum(nil)
 		if !bytes.Equal(sum, data[len(data)-sha1.Size:]) {
-			return errors.StructuralError("private key checksum failure")
+			return errors.StructuralError("private key sha1 failure")
 		}
 		data = data[:len(data)-sha1.Size]
 	} else {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -175,10 +175,8 @@ func (pk *PrivateKey) Serialize(w io.Writer, config *Config) (err error) {
 
 	checksumBytes := getChecksumBytes(privateKeyBytes)
 
-	ptype := packetTypePrivateKey
-	if pk.IsSubkey {
-		ptype = packetTypePrivateSubkey
-	}
+	ptype := getPrivateKeyPacketType(pk)
+
 	err = serializeHeader(w, ptype, len(publicKeyBytes)+len(privateKeyHeaderBytes)+len(privateKeyBytes)+len(checksumBytes))
 	if err != nil {
 		return
@@ -203,6 +201,16 @@ func (pk *PrivateKey) Serialize(w io.Writer, config *Config) (err error) {
 		return
 	}
 
+	return
+}
+
+
+func getPrivateKeyPacketType(pk *PrivateKey) (ptype packetType) {
+	if pk.IsSubkey {
+		ptype = packetTypePrivateSubkey
+	} else {
+		ptype = packetTypePrivateKey
+	}
 	return
 }
 

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -157,7 +157,7 @@ func mod64kHash(d []byte) uint16 {
 	return h
 }
 
-func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
+func (pk *PrivateKey) Serialize(w io.Writer, config *Config) (err error) {
 	// TODO(agl): support encrypted private keys
 
 	publicKeyBytes, err := getPublicKeyBytes(pk)

--- a/openpgp/packet/private_key_test.go
+++ b/openpgp/packet/private_key_test.go
@@ -82,7 +82,7 @@ func TestRSAPrivateKey(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := NewRSAPrivateKey(time.Now(), rsaPriv).Serialize(&buf); err != nil {
+	if err := NewRSAPrivateKey(time.Now(), rsaPriv).Serialize(&buf, &Config{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -125,7 +125,7 @@ func TestECDSAPrivateKey(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := NewECDSAPrivateKey(time.Now(), ecdsaPriv).Serialize(&buf); err != nil {
+	if err := NewECDSAPrivateKey(time.Now(), ecdsaPriv).Serialize(&buf, &Config{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/openpgp/packet/private_key_test.go
+++ b/openpgp/packet/private_key_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"hash"
 	"io"
 	"testing"
@@ -74,6 +75,88 @@ func populateHash(hashFunc crypto.Hash, msg []byte) (hash.Hash, error) {
 	return h, nil
 }
 
+func TestPrivateKeySerialize(t *testing.T) {
+	priv, err := loadTestRSAPrivateKey()
+
+	if err != nil {
+		t.Fatalf("failed to make test private key: %v", err)
+	}
+
+	t.Run("serialize", func(t *testing.T) {
+		b := bytes.NewBuffer(nil)
+
+		if err := priv.Serialize(b, &Config{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestPrivateKeySerializeEncrypted(t *testing.T) {
+	priv, err := loadTestRSAPrivateKey()
+
+	if err != nil {
+		t.Fatalf("failed to make test private key: %v", err)
+	}
+
+	t.Run("serialize with an encryption password", func(t *testing.T) {
+		serialized := bytes.NewBuffer(nil)
+		config := Config{SerializePrivatePassword: "foo"}
+
+		if err := priv.Serialize(serialized, &config); err != nil {
+			t.Fatal(err)
+		}
+
+		// now try to decrypt again
+		p, err := Read(serialized)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		priv, ok := p.(*PrivateKey)
+		if !ok {
+			t.Errorf("didn't parse private key")
+		}
+
+		if !priv.Encrypted {
+			t.Errorf("re-serialized private key apparently isn't encrypted")
+		}
+
+		if !priv.sha1Checksum {
+			t.Errorf("re-serialized private key has sha1Checksum = false")
+		}
+
+		err = priv.Decrypt([]byte("foo"))
+		if err != nil {
+			t.Fatalf("failed to Decrypt re-loaded key: %v", err)
+		}
+	})
+}
+
+func loadTestRSAPrivateKey() (priv *PrivateKey, err error) {
+	privKeyDER, _ := hex.DecodeString(pkcs1PrivKeyHex)
+	rsaPriv, err := x509.ParsePKCS1PrivateKey(privKeyDER)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := NewRSAPrivateKey(time.Now(), rsaPriv).Serialize(&buf, &Config{}); err != nil {
+		return nil, err
+	}
+
+	p, err := Read(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	priv, ok := p.(*PrivateKey)
+	if !ok {
+		return nil, errors.New("didn't parse private key")
+	}
+	return priv, nil
+}
+
 func TestRSAPrivateKey(t *testing.T) {
 	privKeyDER, _ := hex.DecodeString(pkcs1PrivKeyHex)
 	rsaPriv, err := x509.ParsePKCS1PrivateKey(privKeyDER)
@@ -116,6 +199,7 @@ func TestRSAPrivateKey(t *testing.T) {
 	if err := priv.VerifySignature(h, sig); err != nil {
 		t.Fatal(err)
 	}
+
 }
 
 func TestECDSAPrivateKey(t *testing.T) {

--- a/openpgp/write_test.go
+++ b/openpgp/write_test.go
@@ -99,7 +99,7 @@ func TestNewEntity(t *testing.T) {
 	}
 
 	w := bytes.NewBuffer(nil)
-	if err := e.SerializePrivate(w, nil); err != nil {
+	if err := e.SerializePrivate(w, &packet.Config{}); err != nil {
 		t.Errorf("failed to serialize entity: %s", err)
 		return
 	}
@@ -116,7 +116,7 @@ func TestNewEntity(t *testing.T) {
 	}
 
 	w = bytes.NewBuffer(nil)
-	if err := e.SerializePrivate(w, nil); err != nil {
+	if err := e.SerializePrivate(w, &packet.Config{}); err != nil {
 		t.Errorf("failed to serialize entity second time: %s", err)
 		return
 	}


### PR DESCRIPTION
If a password is set (non-empty) in Config.SerializePrivatePassword then
 use this to encrypt the secret key and secret subkey packets.

Some improvements for the future:

* don't hard-code cipher, hash and S2KCount(?)
* pass through Config and use config.Random() rather than rand.Reader