### PR TITLE
Support revocation certificates

### DIFF
--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -638,13 +638,16 @@ func (pk *PublicKey) VerifyKeySignature(signed *PublicKey, sig *Signature) error
 	return nil
 }
 
-func keyRevocationHash(pk signingKey, hashFunc crypto.Hash) (h hash.Hash, err error) {
+// KeyRevocationHash produces a hash over the public key data. This is used
+// to prove that a revocation signature relates to a particular public key.
+// See https://tools.ietf.org/html/rfc4880#section-5.2.4
+
+func KeyRevocationHash(pk signingKey, hashFunc crypto.Hash) (h hash.Hash, err error) {
 	if !hashFunc.Available() {
 		return nil, errors.UnsupportedError("hash function")
 	}
 	h = hashFunc.New()
 
-	// RFC 4880, section 5.2.4
 	pk.SerializeSignaturePrefix(h)
 	pk.serializeWithoutHeaders(h)
 
@@ -654,7 +657,7 @@ func keyRevocationHash(pk signingKey, hashFunc crypto.Hash) (h hash.Hash, err er
 // VerifyRevocationSignature returns nil iff sig is a valid signature, made by this
 // public key.
 func (pk *PublicKey) VerifyRevocationSignature(sig *Signature) (err error) {
-	h, err := keyRevocationHash(pk, sig.Hash)
+	h, err := KeyRevocationHash(pk, sig.Hash)
 	if err != nil {
 		return err
 	}

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -727,5 +727,21 @@ func (sig *Signature) buildSubpackets() (subpackets []outputSubpacket) {
 		subpackets = append(subpackets, outputSubpacket{true, prefCompressionSubpacket, false, sig.PreferredCompression})
 	}
 
+	if sig.SigType == SigTypeKeyRevocation {
+		reasonForRevData := bytes.NewBuffer(nil)
+		reasonForRevData.Write([]byte{*sig.RevocationReason})
+		reasonForRevData.Write([]byte(sig.RevocationReasonText))
+
+		subpackets = append(
+			subpackets,
+			outputSubpacket{
+				hashed:        true,
+				subpacketType: reasonForRevocationSubpacket,
+				isCritical:    false,
+				contents:      reasonForRevData.Bytes(),
+			},
+		)
+	}
+
 	return
 }


### PR DESCRIPTION
* export KeyRevocationHash

  This is to make it possible to generate a revocation certificate from
  outside the package.

* Write out reason for revocation subpacket

  When building subpackets for a Signature, ensure a "reason for revocation"
  subpacket is added if the Signature is a SigTypeKeyRevocation.