### PR TITLE
add capability for non-exportable certifications

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -76,6 +76,8 @@ type Signature struct {
 	// subkey as their own.
 	EmbeddedSignature *Signature
 
+	ExportableCertification *bool
+
 	outSubpackets []outputSubpacket
 }
 
@@ -193,18 +195,19 @@ func parseSignatureSubpackets(sig *Signature, subpackets []byte, isHashed bool) 
 type signatureSubpacketType uint8
 
 const (
-	creationTimeSubpacket        signatureSubpacketType = 2
-	signatureExpirationSubpacket signatureSubpacketType = 3
-	keyExpirationSubpacket       signatureSubpacketType = 9
-	prefSymmetricAlgosSubpacket  signatureSubpacketType = 11
-	issuerSubpacket              signatureSubpacketType = 16
-	prefHashAlgosSubpacket       signatureSubpacketType = 21
-	prefCompressionSubpacket     signatureSubpacketType = 22
-	primaryUserIdSubpacket       signatureSubpacketType = 25
-	keyFlagsSubpacket            signatureSubpacketType = 27
-	reasonForRevocationSubpacket signatureSubpacketType = 29
-	featuresSubpacket            signatureSubpacketType = 30
-	embeddedSignatureSubpacket   signatureSubpacketType = 32
+	creationTimeSubpacket            signatureSubpacketType = 2
+	signatureExpirationSubpacket     signatureSubpacketType = 3
+	exportableCertificationSubpacket signatureSubpacketType = 4
+	keyExpirationSubpacket           signatureSubpacketType = 9
+	prefSymmetricAlgosSubpacket      signatureSubpacketType = 11
+	issuerSubpacket                  signatureSubpacketType = 16
+	prefHashAlgosSubpacket           signatureSubpacketType = 21
+	prefCompressionSubpacket         signatureSubpacketType = 22
+	primaryUserIdSubpacket           signatureSubpacketType = 25
+	keyFlagsSubpacket                signatureSubpacketType = 27
+	reasonForRevocationSubpacket     signatureSubpacketType = 29
+	featuresSubpacket                signatureSubpacketType = 30
+	embeddedSignatureSubpacket       signatureSubpacketType = 32
 )
 
 // parseSignatureSubpacket parses a single subpacket. len(subpacket) is >= 1.
@@ -271,6 +274,17 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 		}
 		sig.SigLifetimeSecs = new(uint32)
 		*sig.SigLifetimeSecs = binary.BigEndian.Uint32(subpacket)
+	case exportableCertificationSubpacket:
+		// Exportable certification, section 5.2.3.11
+		if !isHashed {
+			return
+		}
+		if len(subpacket) != 1 {
+			err = errors.StructuralError("exportable certification subpacket with bad length")
+			return
+		}
+		exportable := subpacket[0] == 1
+		sig.ExportableCertification = &exportable
 	case keyExpirationSubpacket:
 		// Key expiration time, section 5.2.3.6
 		if !isHashed {
@@ -743,5 +757,39 @@ func (sig *Signature) buildSubpackets() (subpackets []outputSubpacket) {
 		)
 	}
 
+	if sig.ExportableCertification != nil && isCertification(sig.SigType) {
+		var exportable byte
+		if *sig.ExportableCertification {
+			exportable = 1
+		} else {
+			exportable = 0
+		}
+
+		subpackets = append(
+			subpackets,
+			outputSubpacket{
+				hashed:        true,
+				subpacketType: exportableCertificationSubpacket,
+				isCritical:    false,
+				contents:      []byte{exportable},
+			},
+		)
+	}
+
 	return
+}
+
+func isCertification(sigType SignatureType) bool {
+	switch sigType {
+	case SigTypeGenericCert:
+		return true
+	case SigTypePersonaCert:
+		return true
+	case SigTypeCasualCert:
+		return true
+	case SigTypePositiveCert:
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
from https://tools.ietf.org/html/rfc4880#section-5.2.3.11:

> (1 octet of exportability, 0 for not, 1 for exportable)
>
> This subpacket denotes whether a certification signature is
> "exportable", to be used by other users than the signature's issuer.
> The packet body contains a Boolean flag indicating whether the
> signature is exportable.  If this packet is not present, the
> certification is exportable; it is equivalent to a flag containing a
> 1.
>
> Non-exportable, or "local", certifications are signatures made by a
> user to mark a key as valid within that user's implementation only.

this means we can make signatures on our team mates' keys that aren't
visible once the key is exported (e.g. sent to a keyserver)